### PR TITLE
FreeBSD: don't use v_cache_min/max

### DIFF
--- a/src/os/darwin/darwin_sigar.c
+++ b/src/os/darwin/darwin_sigar.c
@@ -400,8 +400,10 @@ static int sigar_vmstat(sigar_t *sigar, struct vmmeter *vmstat)
     GET_VM_STATS(vm, v_inactive_target, 0);
     GET_VM_STATS(vm, v_inactive_count, 1);
     GET_VM_STATS(vm, v_cache_count, 1);
-    GET_VM_STATS(vm, v_cache_min, 0);
-    GET_VM_STATS(vm, v_cache_max, 0);
+#if (__FreeBSD_version < 1100079)
+     GET_VM_STATS(vm, v_cache_min, 0);
+     GET_VM_STATS(vm, v_cache_max, 0);
+#endif
     GET_VM_STATS(vm, v_pageout_free_min, 0);
     GET_VM_STATS(vm, v_interrupt_free_min, 0);
     GET_VM_STATS(vm, v_forks, 0);


### PR DESCRIPTION
Hello,

I'm working on getting Diaspora running on FreeBSD and have been running into some gem bundler errors building sigar extensions on FreeBSD. I notice that you are maintaining a fork that is used by `eye`, so I would like to integrate those changes here (as sigar is included in Diaspora's gemfile via bundling`eye`).

This is basically integrating the changes by @swills in https://github.com/hyperic/sigar/pull/68 , which fixes the issue of installing `eye` on FreeBSD 11R and greater.

I would really be very grateful if you could merge and then make a new release of `eye` as needed, then I can hopefully make a PR against Diaspora to bump the gem version.

With this patch I'm able to build the resultant `sigar.so` without issue.
